### PR TITLE
Fix int32 overflows in W4A4 kernels at high resolution

### DIFF
--- a/src/kernels/zgemm/epilogues.cuh
+++ b/src/kernels/zgemm/epilogues.cuh
@@ -242,7 +242,7 @@ public:
 
             if (is_q || is_k) {
                 apply(fpsum,
-                      args.out + bm * BLOCK_M * args.actualN + bn * BLOCK_N,
+                      args.out + (int64_t)bm * BLOCK_M * args.actualN + bn * BLOCK_N,
                       M,
                       N,
                       K,

--- a/src/kernels/zgemm/gemm_base.cuh
+++ b/src/kernels/zgemm/gemm_base.cuh
@@ -680,7 +680,7 @@ public:
             const int n_offset = binfo.bn * BLOCK_N;
 
             unpack_fpsum()(fpsum,
-                           args.out + m_offset * args.actualN + n_offset,
+                           args.out + (int64_t)m_offset * args.actualN + n_offset,
                            args.actualN,
                            args.actualM - m_offset,
                            args.actualN - n_offset,

--- a/src/kernels/zgemm/gemm_w4a4.cuh
+++ b/src/kernels/zgemm/gemm_w4a4.cuh
@@ -1140,7 +1140,7 @@ public:
 
             fpsum_warp fpsum;
 
-            Base::template load_act_to_fpsum<fuse_glu>()(args.input + m_offset * args.actualN + n_offset,
+            Base::template load_act_to_fpsum<fuse_glu>()(args.input + (int64_t)m_offset * args.actualN + n_offset,
                                                          args.actualN,
                                                          args.actualM - m_offset,
                                                          args.actualN - n_offset,

--- a/src/kernels/zgemm/gemm_w4a4_launch_impl.cuh
+++ b/src/kernels/zgemm/gemm_w4a4_launch_impl.cuh
@@ -469,10 +469,10 @@ void GEMM_W4A4_Launch<Config, USE_FP4>::quantize_w4a4_act_fuse_lora(Tensor input
     // assert(oscales.dtype() == Tensor::FP16);
     if (fp4) {
         assert(oscales.dtype() == Tensor::FP8_E4M3);
-        assert(oscales.numel() == M * N / GEMM::WARP_K * 4);
+        assert(oscales.numel() == (int64_t)M * N / GEMM::WARP_K * 4);
     } else {
         assert(isTypeMatch<half_t>(oscales.dtype()));
-        assert(oscales.numel() == M * N / GEMM::WARP_K);
+        assert(oscales.numel() == (int64_t)M * N / GEMM::WARP_K);
     }
 
     const int rank = lora_down.shape[1];
@@ -536,7 +536,7 @@ void GEMM_W4A4_Launch<Config, USE_FP4>::quantize_w4a4_act(Tensor input, Tensor o
 
     // assert(oscales.dtype() == Tensor::FP16);
     assert(isTypeMatch<half_t>(oscales.dtype()));
-    assert(oscales.numel() == M * K / GEMM::WARP_K);
+    assert(oscales.numel() == (int64_t)M * K / GEMM::WARP_K);
 
     dim3 grid(M / GEMM::WARP_M, K / GEMM::WARP_K);
     invoke_kernel<typename GEMM::quantize_w4a4_act_kernel><<<grid, GEMM::WARP_SIZE, 0, getCurrentCUDAStream()>>>(


### PR DESCRIPTION
Several W4A4 code paths compute row-major offsets or size checks in 32-bit int. At high enough resolution (for example a video DiT running at 3840x3840, where a single FFN call exceeds 2^31 elements), the oscales size asserts overflow and abort in debug builds. In release builds the asserts are compiled out and the device-side pointer offsets wrap instead, so the kernels silently read or write out of bounds.

This change promotes the affected products to int64: the two oscales asserts in quantize_w4a4_act_fuse_lora and the matching assert in quantize_w4a4_act, the input pointer offset in quantize_w4a4_fuse_lora_kernel, the fp16 output store offset in the GEMM epilogue (gemm_base.cuh), and the QKV projection epilogue output offset (epilogues.cuh). Remaining per-tile and packed-store offsets stay far below 2^31 at these sizes and are left unchanged.